### PR TITLE
fix song index

### DIFF
--- a/Sources/Yatoro/UI/Pages/DetailPages/ArtistDetailPage.swift
+++ b/Sources/Yatoro/UI/Pages/DetailPages/ArtistDetailPage.swift
@@ -334,7 +334,7 @@ public class ArtistDetailPage: DestroyablePage {
                 // if maxAmountOfItemsDisplayed < songIndex {
                 //     break
                 // }
-                self.topSongsIndicesPlane?.putString("t\(songIndex)", at: (0, 2 + Int32(songIndex * 5)))
+                self.topSongsIndicesPlane?.putString("s\(songIndex)", at: (0, 2 + Int32(songIndex * 5)))
             }
         }
 


### PR DESCRIPTION
Changed: Top songs index display from t0, t1, t2... to s0, s1, s2...
Why: The command system  expects s0 for top songs, not t0
Impact: Users can now successfully use commands like :o s0 or :a s1 to access top songs