### PR TITLE
Fix(ui): HelpPage Crash Prevention, Layout, and Content Updates

### DIFF
--- a/Sources/Yatoro/Music/SearchManager.swift
+++ b/Sources/Yatoro/Music/SearchManager.swift
@@ -151,12 +151,15 @@ public class SearchManager: @unchecked Sendable {
     }
 
     public func showHelp() {
+        if case .help = lastSearchResult?.result {
+            return
+        }
         self.lastSearchResult = ResultNode(previous: lastSearchResult, .help, inPlace: false)
     }
 
 }
 
-// Requesting
+// MARK: - Requesting
 public extension SearchManager {
 
     func getRecentlyPlayed<T>(

--- a/Sources/Yatoro/UI/Managers/UIPageManager.swift
+++ b/Sources/Yatoro/UI/Managers/UIPageManager.swift
@@ -208,6 +208,18 @@ public struct UIPageManager {
                 height: newHeight
             )
         )
+        
+        // Resize HelpPage if active
+        if let helpPage = HelpPage.active {
+            await helpPage.resizeToParent(
+                .init(
+                    absX: 0,
+                    absY: 0,
+                    width: newWidth,
+                    height: newHeight
+                )
+            )
+        }
     }
 
     public func onQuit() async {

--- a/Sources/Yatoro/UI/Pages/HelpPage.swift
+++ b/Sources/Yatoro/UI/Pages/HelpPage.swift
@@ -68,7 +68,8 @@ public class HelpPage: DestroyablePage {
     public func onResize(newPageState: PageState) async {
         self.state = newPageState
         
-        guard state.width > HelpPage.minPageWidth, state.height > HelpPage.minPageHeight else {
+        guard state.width >= UInt32(HelpPage.minPageWidth),
+              state.height >= UInt32(HelpPage.minPageHeight) else {
             return
         }
         

--- a/Sources/Yatoro/UI/Pages/HelpPage.swift
+++ b/Sources/Yatoro/UI/Pages/HelpPage.swift
@@ -110,16 +110,6 @@ public class HelpPage: DestroyablePage {
         renderHelpContent()
     }
     
-    // MARK: - Input Handling
-    public func handleInput(_ input: Input) async -> Bool {
-        // Only allow closing via ESC or q
-        if input.id == 27 || input.utf8 == "q" {
-             await self.destroy()
-             return true
-        }
-        return false
-    }
-
     public func getMinDimensions() async -> (width: UInt32, height: UInt32) { (50, 20) }
 
     public func getMaxDimensions() async -> (width: UInt32, height: UInt32)? { nil }

--- a/Sources/Yatoro/UI/Pages/HelpPage.swift
+++ b/Sources/Yatoro/UI/Pages/HelpPage.swift
@@ -7,14 +7,71 @@ public class HelpPage: DestroyablePage {
 
     private let plane: Plane
     private let pagePlane: Plane
-    private let pageNamePlane: Plane
     private let borderPlane: Plane
+    private let pageNamePlane: Plane
     private let contentPlane: Plane
 
     private var state: PageState
+    // MARK: - Properties
+    
+    // Active reference
+    /// The currently active HelpPage instance.
+    public static weak var active: HelpPage?
+    // MARK: - Constants
+    
+    private static let minPageWidth: Int32 = 4
+    private static let minPageHeight: Int32 = 4
+    private static let defaultMarginX: Int32 = 5
+    private static let defaultMarginTop: Int32 = 2
+    private static let defaultMarginBottom: Int32 = 4
+
+    // MARK: - Layout Logic
+    
+    /// Calculates the optimal layout for the HelpPage based on the parent's dimensions.
+    /// - Parameter parentState: The state of the parent container (usually the window or main content area).
+    /// - Returns: A new `PageState` with calculated position and size, ensuring the page fits within bounds.
+    public static func layout(forParent parentState: PageState) -> PageState {
+        let parentWidth = Int32(parentState.width)
+        let parentHeight = Int32(parentState.height)
+        
+        var marginX: Int32 = defaultMarginX
+        var marginTop: Int32 = defaultMarginTop
+        var marginBottom: Int32 = defaultMarginBottom
+        
+        // Dynamically reduce margins if the window is too small to fit content
+        if parentWidth < (minPageWidth + marginX * 2) {
+            marginX = max(0, (parentWidth - minPageWidth) / 2)
+        }
+        if parentHeight < (minPageHeight + marginTop + marginBottom) {
+            let availableMargin = max(0, parentHeight - minPageHeight)
+            // Distribute approx 1/3 top, 2/3 bottom
+            marginTop = availableMargin / 3
+            marginBottom = availableMargin - marginTop
+        }
+        
+        let newWidth = max(minPageWidth, parentWidth - (marginX * 2))
+        let newHeight = max(minPageHeight, parentHeight - (marginTop + marginBottom))
+        
+        return PageState(
+            absX: marginX,
+            absY: marginTop,
+            width: UInt32(newWidth),
+            height: UInt32(newHeight)
+        )
+    }
+    
+    /// Resizes the HelpPage to fit within the given parent state, using the standard layout logic.
+    public func resizeToParent(_ parentState: PageState) async {
+        await onResize(newPageState: HelpPage.layout(forParent: parentState))
+    }
 
     public func onResize(newPageState: PageState) async {
         self.state = newPageState
+        
+        guard state.width > HelpPage.minPageWidth, state.height > HelpPage.minPageHeight else {
+            return
+        }
+        
         plane.updateByPageState(state)
         
         pagePlane.updateByPageState(
@@ -26,7 +83,7 @@ public class HelpPage: DestroyablePage {
             )
         )
         pagePlane.blank()
-        
+
         borderPlane.updateByPageState(
             .init(
                 absX: 0,
@@ -37,7 +94,9 @@ public class HelpPage: DestroyablePage {
         )
         borderPlane.erase()
         borderPlane.windowBorder(width: state.width, height: state.height)
-        
+
+        pageNamePlane.updateByPageState(.init(absX: 2, absY: 0, width: 4, height: 1))
+
         contentPlane.updateByPageState(
             .init(
                 absX: 2,
@@ -50,17 +109,30 @@ public class HelpPage: DestroyablePage {
         
         renderHelpContent()
     }
+    
+    // MARK: - Input Handling
+    public func handleInput(_ input: Input) async -> Bool {
+        // Only allow closing via ESC or q
+        if input.id == 27 || input.utf8 == "q" {
+             await self.destroy()
+             return true
+        }
+        return false
+    }
 
     public func getMinDimensions() async -> (width: UInt32, height: UInt32) { (50, 20) }
 
     public func getMaxDimensions() async -> (width: UInt32, height: UInt32)? { nil }
 
     public func getPageState() async -> PageState { self.state }
-
+    
     public init?(
         stdPlane: Plane,
         state: PageState
     ) {
+        if state.width <= HelpPage.minPageWidth || state.height <= HelpPage.minPageHeight {
+            return nil
+        }
         self.state = state
         guard
             let plane = Plane(
@@ -90,22 +162,6 @@ public class HelpPage: DestroyablePage {
         self.borderPlane = borderPlane
 
         guard
-            let pageNamePlane = Plane(
-                in: plane,
-                state: .init(
-                    absX: 2,
-                    absY: 0,
-                    width: 4,
-                    height: 1
-                ),
-                debugID: "HELP_NAME"
-            )
-        else {
-            return nil
-        }
-        self.pageNamePlane = pageNamePlane
-
-        guard
             let pagePlane = Plane(
                 in: plane,
                 state: .init(
@@ -114,12 +170,29 @@ public class HelpPage: DestroyablePage {
                     width: state.width - 2,
                     height: state.height - 2
                 ),
-                debugID: "HELP_PAGE"
+                debugID: "HELP_PAGE_BG"
             )
         else {
             return nil
         }
         self.pagePlane = pagePlane
+
+
+        guard
+            let pageNamePlane = Plane(
+                in: plane,
+                state: .init(
+                    absX: 2,
+                    absY: 0,
+                    width: 4,
+                    height: 1
+                ),
+                debugID: "HELP_PAGE_NAME"
+            )
+        else {
+            return nil
+        }
+        self.pageNamePlane = pageNamePlane
 
         guard
             let contentPlane = Plane(
@@ -138,99 +211,130 @@ public class HelpPage: DestroyablePage {
         self.contentPlane = contentPlane
 
         updateColors()
+        
+        HelpPage.active = self
     }
 
     public func updateColors() {
-        let colorConfig = Theme.shared.nowPlaying // Reuse now playing colors for consistency
+        let colorConfig = Theme.shared.nowPlaying 
+        
+        plane.setColorPair(colorConfig.page)
+        pagePlane.setColorPair(colorConfig.page)
         borderPlane.setColorPair(colorConfig.border)
         pageNamePlane.setColorPair(colorConfig.pageName)
-        pagePlane.setColorPair(colorConfig.page)
         contentPlane.setColorPair(colorConfig.page)
-
+        
+        plane.blank()
         borderPlane.windowBorder(width: state.width, height: state.height)
         pageNamePlane.putString("Help", at: (0, 0))
         pagePlane.blank()
         
-        Task {
-            await onResize(newPageState: self.state)
-        }
+        contentPlane.blank()
+        renderHelpContent()
     }
 
     private func renderHelpContent() {
         contentPlane.erase()
-        
-        let width = Int(contentPlane.width)
-        let midPoint = width / 2
+
         
         var row: Int32 = 0
+        
+        renderGeneralHelp(row: &row)
+        
+        // Footer
+        row += 2
+        contentPlane.putString("Press ESC to close this help page", at: (0, row))
+    }
+
+
+
+    private func renderGeneralHelp(row: inout Int32) {
+        let width = Int(contentPlane.width)
+        let midPoint = width / 2
         
         // Title
         contentPlane.putString("Yatoro Help - Commands and Key Bindings", at: (0, row))
         row += 2
         
-        // Column headers
+        // Table Headers
         contentPlane.putString("COMMANDS:", at: (0, row))
         contentPlane.putString("KEY BINDINGS:", at: (Int32(midPoint), row))
         row += 1
         
-        contentPlane.putString("=========", at: (0, row))
-        contentPlane.putString("=============", at: (Int32(midPoint), row))
+        // Header Separator
+        let leftSep = String(repeating: "=", count: 9) // Length of "COMMANDS:"
+        let rightSep = String(repeating: "=", count: 13) // Length of "KEY BINDINGS:"
+        contentPlane.putString(leftSep, at: (0, row))
+        contentPlane.putString(rightSep, at: (Int32(midPoint), row))
         row += 1
         
-        // Generate commands and key bindings
-        let commands = Command.defaultCommands.sorted(by: { $0.name < $1.name })
-        let mappings = Mapping.defaultMappings.sorted(by: { $0.key < $1.key })
+        let commands = Command.defaultCommands
+        let mappings = Config.shared.mappings
         
-        let maxRows = min(max(commands.count, mappings.count), 15) // Limit for testing
-        
-        for i in 0..<maxRows {
-            // Left column - Commands
-            if i < commands.count {
-                let command = commands[i]
-                let shortName = command.shortName ?? ""
-                let nameWithShort = shortName.isEmpty ? command.name : "\(command.name) (\(shortName))"
-                let commandText = ":\(nameWithShort)"
-                contentPlane.putString(commandText, at: (0, row))
+        for command in commands {
+            // Left Column: Command
+            let commandPart = ":\(command.name)"
+            contentPlane.putString(commandPart, at: (0, row))
+            
+            // Right Column: Shortcut -> Binding
+            var rightTextParts: [String] = []
+            
+            if let shortName = command.shortName, !shortName.isEmpty {
+                rightTextParts.append(":\(shortName)")
             }
             
-            // Right column - Key bindings
-            if i < mappings.count {
-                let mapping = mappings[i]
-                let modStr = mapping.modifiers?.map { $0.rawValue.capitalized }.joined(separator: "+") ?? ""
-                let keyDisplay = modStr.isEmpty ? mapping.key : "\(modStr)+\(mapping.key)"
-                let actionClean = mapping.action.replacingOccurrences(of: "<CR>", with: "").replacingOccurrences(of: ":", with: "")
-                let bindingText = "\(keyDisplay) → \(actionClean)"
-                contentPlane.putString(bindingText, at: (Int32(midPoint), row))
+            let prefix = ":\(command.name)"
+            if let mapping = mappings.first(where: { m in
+                 let action = m.action
+                 guard action.hasPrefix(prefix) else { return false }
+                 let suffix = action.dropFirst(prefix.count)
+                 return suffix.isEmpty || suffix.hasPrefix("<") || suffix.hasPrefix(" ")
+            }) {
+                rightTextParts.append(mapping.displayKey)
+            }
+            
+            if !rightTextParts.isEmpty {
+                let rightText = rightTextParts.joined(separator: " -> ")
+                contentPlane.putString(rightText, at: (Int32(midPoint), row))
             }
             
             row += 1
         }
-        
-        // Footer
-        row += 2
-        contentPlane.putString("Type :help or :h in command mode to open this help page", at: (0, row))
-        row += 1
-        contentPlane.putString("Press ESC to close this help page", at: (0, row))
     }
 
     public func render() async {
-        // Help page is static, no need to update
+        // Help page is static
     }
 
     public func destroy() async {
-        self.plane.erase()
-        self.plane.destroy()
-
         self.borderPlane.erase()
         self.borderPlane.destroy()
-
-        self.pagePlane.erase()
-        self.pagePlane.destroy()
-
+        
         self.pageNamePlane.erase()
         self.pageNamePlane.destroy()
-
+        
+        self.pagePlane.erase()
+        self.pagePlane.destroy()
+        
         self.contentPlane.erase()
         self.contentPlane.destroy()
+        
+        self.plane.erase()
+        self.plane.destroy()
+        
+        if HelpPage.active === self {
+            HelpPage.active = nil
+        }
+    }
+}
+
+// MARK: - Mapping Display Extension
+extension Mapping {
+    var displayKey: String {
+        guard let modifiers = modifiers, !modifiers.isEmpty else {
+            return key
+        }
+        let keyStr = modifiers.map { $0.rawValue.uppercased() }.joined(separator: "+")
+        return "\(keyStr)+\(key)"
     }
 }

--- a/Sources/Yatoro/UI/Pages/SearchPage.swift
+++ b/Sources/Yatoro/UI/Pages/SearchPage.swift
@@ -387,12 +387,7 @@ public class SearchPage: DestroyablePage {
         case .help:
             let helpPage = HelpPage(
                 stdPlane: stdPlane,
-                state: .init(
-                    absX: 5,
-                    absY: 2,
-                    width: stdPlane.width - 10,
-                    height: stdPlane.height - 6
-                )
+                state: HelpPage.layout(forParent: .init(absX: 0, absY: 0, width: stdPlane.width, height: stdPlane.height))
             )
             SearchPage.searchPageQueue = .init(SearchPage.searchPageQueue, page: helpPage, type: result)
 


### PR DESCRIPTION
## Summary
Addressed runtime crashes on small window resizing, improved the `HelpPage` implementation for robustness, and expanded the help content to include missing items.

## Changes
Before             |  After
:-------------------------:|:-------------------------:
![](https://github.com/user-attachments/assets/470c0d9c-7d89-4d67-892a-85f3bdc00e30)  |  ![](https://github.com/user-attachments/assets/b2ffb011-adf9-4a3d-a178-5f0d52b63a14)

- **Content Check:** Added missing items to the Help Page layout, ensuring all available commands are displayed without arbitrary limits.
- **Crash Fix:** Enforced minimum dimensions (`4x4`) for the `HelpPage` to prevent `SwiftNotCurses` crashes caused by arithmetic underflow when margins exceed plane size.
- **Dynamic Layout:** Implemented a new static helper `HelpPage.layout(forParent:)` that dynamically reduces margins on small screens, fixing the "empty details" visual bug.
- **Refactoring:** 
  - Extracted magic numbers into named private constants.
  - Added comprehensive SwiftDoc comments.
  - Aligned [SearchPage.swift](cci:7://file:///Users/invincible/Downloads/Yatoro-0.3.4/Sources/Yatoro/UI/Pages/SearchPage.swift:0:0-0:0) initialization strategy with other pages (explicit state passing) while using the safe layout logic.
- **Visual Fix:** Restored `pagePlane` rendering to ensure the background is cleared correctly during updates.
- Related to: #43 
## Testing
- **Verification:** Verified that the Help Page displays the complete list of commands and behaves correctly when resizing.