### PR TITLE
Fix Unicode command input in Ghostty

### DIFF
--- a/Sources/Yatoro/Commands/CommandInput.swift
+++ b/Sources/Yatoro/Commands/CommandInput.swift
@@ -57,8 +57,10 @@ public actor CommandInput {
         guard !newInput.utf8.isEmpty else {
             return
         }
-        inputs.insert(Character(newInput.utf8), at: cursorPositionInWord)
-        cursorPositionInWord += 1
+        for char in newInput.utf8 {
+            inputs.insert(char, at: cursorPositionInWord)
+            cursorPositionInWord += 1
+        }
     }
 
     public func getCursorPosition() async -> Int {

--- a/Sources/Yatoro/Extensions/String.swift
+++ b/Sources/Yatoro/Extensions/String.swift
@@ -1,0 +1,12 @@
+import Darwin
+
+public extension String {
+
+    var terminalColumnWidth: UInt32 {
+        unicodeScalars.reduce(UInt32(0)) { width, scalar in
+            let scalarWidth = wcwidth(wchar_t(scalar.value))
+            return width + UInt32(scalarWidth >= 0 ? scalarWidth : 1)
+        }
+    }
+
+}

--- a/Sources/Yatoro/Music/MusicPlayer.swift
+++ b/Sources/Yatoro/Music/MusicPlayer.swift
@@ -11,6 +11,8 @@ public typealias CatalogTopResult = MusicCatalogSearchResponse.TopResult
 extension CatalogTopResult: @retroactive MusicCatalogSearchable {}
 extension LibraryTopResult: @retroactive MusicLibrarySearchable {}
 
+@MainActor private var restoredQueueSongs: [Song]?
+
 public final class AudioPlayerManager: Sendable {
 
     @MainActor static let shared = AudioPlayerManager()
@@ -35,6 +37,18 @@ public final class AudioPlayerManager: Sendable {
         )
         return entries
 
+    }
+
+    @MainActor public var queueSongs: [Song] {
+        if let restoredQueueSongs {
+            return restoredQueueSongs
+        }
+        return queue.compactMap { entry -> Song? in
+            switch entry.item {
+            case .song(let song): return song
+            default: return nil
+            }
+        }
     }
 
     var nowPlaying: Song? {
@@ -185,12 +199,14 @@ public extension AudioPlayerManager {
         }
     }
 
-    func clearQueue() async {
+    @MainActor func clearQueue() async {
         player.stop()
         player.queue.entries = []
+        restoredQueueSongs = nil
+        await QueuePersistence.save(songs: [])
     }
 
-    func addItemsToQueue<T>(
+    @MainActor func addItemsToQueue<T>(
         items: MusicItemCollection<T>,
         at position: ApplicationMusicPlayer.Queue.EntryInsertionPosition
     ) async
@@ -202,19 +218,56 @@ public extension AudioPlayerManager {
                 try await player.queue.insert(items, position: position)
             }
         } catch {
-            await logger?.error(
+            logger?.error(
                 "Unable to add songs to player queue: \(error.localizedDescription)"
             )
             return
         }
         do {
             if !player.isPreparedToPlay {
-                await logger?.trace("Preparing player...")
+                logger?.trace("Preparing player...")
                 try await player.prepareToPlay()
             }
         } catch {
-            await logger?.critical("Unable to prepare player: \(error.localizedDescription)")
+            logger?.critical("Unable to prepare player: \(error.localizedDescription)")
         }
+        restoredQueueSongs = nil
+        await saveQueue()
+    }
+
+    @MainActor func restoreQueue() async {
+        guard player.queue.entries.isEmpty else {
+            return
+        }
+        guard let songs = await QueuePersistence.load() else {
+            return
+        }
+
+        let restoredSongs = Array(songs)
+        guard let firstSong = restoredSongs.first else {
+            return
+        }
+        restoredQueueSongs = restoredSongs
+
+        player.queue = .init(for: MusicItemCollection<Song>([firstSong]))
+        do {
+            logger?.trace("Preparing player with restored queue...")
+            try await player.prepareToPlay()
+            let remainingSongs = Array(restoredSongs.dropFirst())
+            if !remainingSongs.isEmpty {
+                try await player.queue.insert(
+                    MusicItemCollection<Song>(remainingSongs),
+                    position: .tail
+                )
+            }
+            logger?.debug("Restored queue from \(QueuePersistence.queueURL.path).")
+        } catch {
+            logger?.critical("Unable to prepare restored queue: \(error.localizedDescription)")
+        }
+    }
+
+    @MainActor private func saveQueue() async {
+        await QueuePersistence.save(songs: queueSongs)
     }
 
     func setTime(

--- a/Sources/Yatoro/Music/QueuePersistence.swift
+++ b/Sources/Yatoro/Music/QueuePersistence.swift
@@ -1,0 +1,71 @@
+import Foundation
+import MusicKit
+
+struct PersistedQueue: Codable {
+    var songs: [MusicItemID]
+}
+
+enum QueuePersistence {
+    static let queueURL: URL = {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".config", isDirectory: true)
+            .appendingPathComponent("Yatoro", isDirectory: true)
+            .appendingPathComponent("queue.json", isDirectory: false)
+    }()
+
+    static func save(songs: [Song]) async {
+        do {
+            try FileManager.default.createDirectory(
+                at: queueURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+
+            let persistedQueue = PersistedQueue(songs: songs.map(\.id))
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            let data = try encoder.encode(persistedQueue)
+            try data.write(to: queueURL, options: .atomic)
+            await logger?.debug("Saved queue to \(queueURL.path).")
+        } catch {
+            await logger?.error("Unable to save queue: \(error.localizedDescription)")
+        }
+    }
+
+    static func load() async -> MusicItemCollection<Song>? {
+        guard FileManager.default.fileExists(atPath: queueURL.path) else {
+            return nil
+        }
+
+        do {
+            let data = try Data(contentsOf: queueURL)
+            let persistedQueue = try JSONDecoder().decode(PersistedQueue.self, from: data)
+            guard !persistedQueue.songs.isEmpty else {
+                return nil
+            }
+
+            var request = MusicCatalogResourceRequest<Song>(
+                matching: \.id,
+                memberOf: persistedQueue.songs
+            )
+            request.limit = persistedQueue.songs.count
+            let response = try await request.response()
+
+            let songsByID = Dictionary(uniqueKeysWithValues: response.items.map { ($0.id, $0) })
+            let songs = persistedQueue.songs.compactMap { songsByID[$0] }
+            guard !songs.isEmpty else {
+                await logger?.debug("Queue file did not contain restorable songs.")
+                return nil
+            }
+
+            if songs.count != persistedQueue.songs.count {
+                await logger?.warning(
+                    "Restored \(songs.count) of \(persistedQueue.songs.count) queued songs."
+                )
+            }
+            return MusicItemCollection(songs)
+        } catch {
+            await logger?.error("Unable to load queue: \(error.localizedDescription)")
+            return nil
+        }
+    }
+}

--- a/Sources/Yatoro/UI/Pages/CommandPage.swift
+++ b/Sources/Yatoro/UI/Pages/CommandPage.swift
@@ -392,7 +392,7 @@ public class CommandPage: Page {
         }
         completionsPlane.moveOnTopOfZStack()
         completionSelectedPlane.moveOnTopOfZStack()
-        let completionsLengths = inputQueue.completionCommands.map({ UInt32($0.count) })
+        let completionsLengths = inputQueue.completionCommands.map(\.terminalColumnWidth)
         let maxCompletionLength = (completionsLengths.max() ?? 1) + 5
         let yPos = state.absY - Int32(completionsDisplayedAmount) + 1
 
@@ -499,7 +499,7 @@ public class CommandPage: Page {
                 .init(
                     absX: x,
                     absY: 0,
-                    width: UInt32(nowPlaying.title.count),
+                    width: nowPlaying.title.terminalColumnWidth,
                     height: 1
                 )
             )
@@ -511,7 +511,7 @@ public class CommandPage: Page {
                 .init(
                     absX: x,
                     absY: 0,
-                    width: UInt32(nowPlaying.artistName.count),
+                    width: nowPlaying.artistName.terminalColumnWidth,
                     height: 1
                 )
             )
@@ -530,7 +530,7 @@ public class CommandPage: Page {
                 .init(
                     absX: nowPlayingDashPlane.x + 2,
                     absY: 0,
-                    width: UInt32(nowPlaying.title.count),
+                    width: nowPlaying.title.terminalColumnWidth,
                     height: 1
                 )
             )

--- a/Sources/Yatoro/UI/Pages/DetailPages/AlbumDetailPage.swift
+++ b/Sources/Yatoro/UI/Pages/DetailPages/AlbumDetailPage.swift
@@ -87,7 +87,7 @@ public class AlbumDetailPage: DestroyablePage {
                 state: .init(
                     absX: 4,
                     absY: 2,
-                    width: UInt32(title.count),
+                    width: title.terminalColumnWidth,
                     height: 1
                 ),
                 debugID: "ADTP"

--- a/Sources/Yatoro/UI/Pages/DetailPages/ArtistDetailPage.swift
+++ b/Sources/Yatoro/UI/Pages/DetailPages/ArtistDetailPage.swift
@@ -86,7 +86,7 @@ public class ArtistDetailPage: DestroyablePage {
                 state: .init(
                     absX: 4,
                     absY: 2,
-                    width: UInt32(artistName.count),
+                    width: artistName.terminalColumnWidth,
                     height: 1
                 ),
                 debugID: "ARDPTP"

--- a/Sources/Yatoro/UI/Pages/DetailPages/PlaylistDetailPage.swift
+++ b/Sources/Yatoro/UI/Pages/DetailPages/PlaylistDetailPage.swift
@@ -83,7 +83,7 @@ public class PlaylistDetailPage: DestroyablePage {
                 state: .init(
                     absX: 4,
                     absY: 2,
-                    width: UInt32(title.count),
+                    width: title.terminalColumnWidth,
                     height: 1
                 ),
                 debugID: "PDTP"

--- a/Sources/Yatoro/UI/Pages/DetailPages/RecommendationDetailPage.swift
+++ b/Sources/Yatoro/UI/Pages/DetailPages/RecommendationDetailPage.swift
@@ -71,7 +71,7 @@ public class RecommendationDetailPage: DestroyablePage {
                     state: .init(
                         absX: 4,
                         absY: 0,
-                        width: UInt32(title.count),
+                        width: title.terminalColumnWidth,
                         height: 1
                     ),
                     debugID: "RDTP"

--- a/Sources/Yatoro/UI/Pages/DetailPages/SongDetailPage.swift
+++ b/Sources/Yatoro/UI/Pages/DetailPages/SongDetailPage.swift
@@ -87,7 +87,7 @@ public class SongDetailPage: DestroyablePage {
                 state: .init(
                     absX: 4,
                     absY: 2,
-                    width: UInt32(title.count),
+                    width: title.terminalColumnWidth,
                     height: 1
                 ),
                 debugID: "SDTP"

--- a/Sources/Yatoro/UI/Pages/Items/AlbumItemPage.swift
+++ b/Sources/Yatoro/UI/Pages/Items/AlbumItemPage.swift
@@ -103,7 +103,7 @@ public class AlbumItemPage: DestroyablePage {
         self.artistLeftPlane = artistLeftPlane
         self.artistLeftPlane.moveAbove(other: self.pageNamePlane)
 
-        let artistRightWidth = min(UInt32(item.artistName.count), state.width - 11)
+        let artistRightWidth = min(item.artistName.terminalColumnWidth, state.width - 11)
         guard
             let artistRightPlane = Plane(
                 in: pagePlane,
@@ -148,7 +148,7 @@ public class AlbumItemPage: DestroyablePage {
         if genreStr.count >= 2 {
             genreStr.removeLast(2)
         }
-        let genreRightWidth = min(UInt32(genreStr.count), state.width - 10)
+        let genreRightWidth = min(genreStr.terminalColumnWidth, state.width - 10)
         guard
             let genreRightPlane = Plane(
                 in: pagePlane,
@@ -183,7 +183,7 @@ public class AlbumItemPage: DestroyablePage {
         self.albumLeftPlane = albumLeftPlane
         self.albumLeftPlane.moveAbove(other: self.genreRightPlane)
 
-        let albumRightWidth = min(UInt32(item.title.count), state.width - 10)
+        let albumRightWidth = min(item.title.terminalColumnWidth, state.width - 10)
         guard
             let albumRightPlane = Plane(
                 in: pagePlane,

--- a/Sources/Yatoro/UI/Pages/Items/ArtistItemPage.swift
+++ b/Sources/Yatoro/UI/Pages/Items/ArtistItemPage.swift
@@ -109,7 +109,7 @@ public class ArtistItemPage: DestroyablePage {
         self.artistLeftPlane = artistLeftPlane
         self.artistLeftPlane.moveAbove(other: self.pageNamePlane)
 
-        let artistRightWidth = min(UInt32(item.name.count), state.width - 11)
+        let artistRightWidth = min(item.name.terminalColumnWidth, state.width - 11)
         guard
             let artistRightPlane = Plane(
                 in: pagePlane,
@@ -152,7 +152,7 @@ public class ArtistItemPage: DestroyablePage {
             if genreStr.count >= 2 {
                 genreStr.removeLast(2)
             }
-            let genreRightWidth = min(UInt32(genreStr.count), state.width - 10)
+            let genreRightWidth = min(genreStr.terminalColumnWidth, state.width - 10)
             guard
                 let genreRightPlane = Plane(
                     in: pagePlane,
@@ -203,7 +203,7 @@ public class ArtistItemPage: DestroyablePage {
             if albumsStr.count >= 2 {
                 albumsStr.removeLast(2)
             }
-            let albumsRightWidth = min(UInt32(albumsStr.count), state.width - 11)
+            let albumsRightWidth = min(albumsStr.terminalColumnWidth, state.width - 11)
             guard
                 let albumsRightPlane = Plane(
                     in: pagePlane,

--- a/Sources/Yatoro/UI/Pages/Items/PlaylistItemPage.swift
+++ b/Sources/Yatoro/UI/Pages/Items/PlaylistItemPage.swift
@@ -101,7 +101,7 @@ public class PlaylistItemPage: DestroyablePage {
         self.playlistLeftPlane = playlistLeftPlane
         self.playlistLeftPlane.moveAbove(other: self.pageNamePlane)
 
-        let playlistRightWidth = min(UInt32(item.name.count), state.width - 13)
+        let playlistRightWidth = min(item.name.terminalColumnWidth, state.width - 13)
         guard
             let playlistRightPlane = Plane(
                 in: pagePlane,
@@ -136,7 +136,7 @@ public class PlaylistItemPage: DestroyablePage {
         self.descriptionLeftPlane = descriptionLeftPlane
         self.descriptionLeftPlane.moveAbove(other: self.playlistRightPlane)
 
-        var descriptionRightWidth = min(UInt32(item.standardDescription?.count ?? 1), state.width - 16)
+        var descriptionRightWidth = min((item.standardDescription ?? " ").terminalColumnWidth, state.width - 16)
         if descriptionRightWidth == 0 { descriptionRightWidth = 1 }
         guard
             let descriptionRightPlane = Plane(
@@ -172,7 +172,7 @@ public class PlaylistItemPage: DestroyablePage {
         self.curatorLeftPlane = curatorLeftPlane
         self.curatorLeftPlane.moveAbove(other: self.descriptionRightPlane)
 
-        let curatorRightWidth = min(UInt32(item.curatorName?.count ?? 1), state.width - 12)
+        let curatorRightWidth = min((item.curatorName ?? " ").terminalColumnWidth, state.width - 12)
         guard
             let curatorRightPlane = Plane(
                 in: pagePlane,

--- a/Sources/Yatoro/UI/Pages/Items/RecommendationItemPage.swift
+++ b/Sources/Yatoro/UI/Pages/Items/RecommendationItemPage.swift
@@ -93,7 +93,7 @@ public class RecommendationItemPage: DestroyablePage {
         self.titleLeftPlane.moveAbove(other: self.pageNamePlane)
 
         if let title = item.title {
-            let titleRightWidth = min(UInt32(title.count), state.width - 10)
+            let titleRightWidth = min(title.terminalColumnWidth, state.width - 10)
             guard
                 let titleRightPlane = Plane(
                     in: pagePlane,
@@ -138,7 +138,7 @@ public class RecommendationItemPage: DestroyablePage {
         if typesStr.count >= 2 {
             typesStr.removeLast(2)
         }
-        let typesRightWidth = min(UInt32(typesStr.count), state.width - 10)
+        let typesRightWidth = min(typesStr.terminalColumnWidth, state.width - 10)
         guard
             let typesRightPlane = Plane(
                 in: pagePlane,
@@ -174,7 +174,7 @@ public class RecommendationItemPage: DestroyablePage {
         self.refreshDateLeftPlane.moveAbove(other: self.typesRightPlane)
 
         if let refreshDate = item.nextRefreshDate?.formatted() {
-            let refreshDateRightWidth = min(UInt32(refreshDate.count), state.width - 12)
+            let refreshDateRightWidth = min(refreshDate.terminalColumnWidth, state.width - 12)
             guard
                 let refreshDateRightPlane = Plane(
                     in: pagePlane,

--- a/Sources/Yatoro/UI/Pages/Items/SongItemPage.swift
+++ b/Sources/Yatoro/UI/Pages/Items/SongItemPage.swift
@@ -104,7 +104,7 @@ public class SongItemPage: DestroyablePage {
         self.artistLeftPlane = artistLeftPlane
         self.artistLeftPlane.moveAbove(other: self.pageNamePlane)
 
-        let artistRightWidth = min(UInt32(item.artistName.count), state.width - 11)
+        let artistRightWidth = min(item.artistName.terminalColumnWidth, state.width - 11)
         guard
             let artistRightPlane = Plane(
                 in: pagePlane,
@@ -139,7 +139,7 @@ public class SongItemPage: DestroyablePage {
         self.songLeftPlane = songLeftPlane
         self.songLeftPlane.moveAbove(other: self.artistRightPlane)
 
-        let songRightWidth = min(UInt32(item.title.count), state.width - 9)
+        let songRightWidth = min(item.title.terminalColumnWidth, state.width - 9)
         guard
             let songRightPlane = Plane(
                 in: pagePlane,
@@ -174,7 +174,7 @@ public class SongItemPage: DestroyablePage {
         self.albumLeftPlane = albumLeftPlane
         self.albumLeftPlane.moveAbove(other: self.songRightPlane)
 
-        let albumRightWidth = min(UInt32(item.albumTitle?.count ?? 1), state.width - 10)
+        let albumRightWidth = min((item.albumTitle ?? " ").terminalColumnWidth, state.width - 10)
         guard
             let albumRightPlane = Plane(
                 in: pagePlane,

--- a/Sources/Yatoro/UI/Pages/Items/StationItemPage.swift
+++ b/Sources/Yatoro/UI/Pages/Items/StationItemPage.swift
@@ -101,7 +101,7 @@ public class StationItemPage: DestroyablePage {
         self.stationLeftPlane = stationLeftPlane
         self.stationLeftPlane.moveAbove(other: self.pageNamePlane)
 
-        let stationRightWidth = min(UInt32(item.name.count), state.width - 12)
+        let stationRightWidth = min(item.name.terminalColumnWidth, state.width - 12)
         guard
             let stationRightPlane = Plane(
                 in: pagePlane,
@@ -136,7 +136,7 @@ public class StationItemPage: DestroyablePage {
         self.notesLeftPlane = notesLeftPlane
         self.notesLeftPlane.moveAbove(other: self.stationRightPlane)
 
-        var notesRightWidth = min(UInt32(item.editorialNotes?.standard?.count ?? 1), state.width - 10)
+        var notesRightWidth = min((item.editorialNotes?.standard ?? " ").terminalColumnWidth, state.width - 10)
         if notesRightWidth == 0 { notesRightWidth = 1 }
         guard
             let notesRightPlane = Plane(
@@ -172,7 +172,7 @@ public class StationItemPage: DestroyablePage {
         self.isLiveLeftPlane = isLiveLeftPlane
         self.isLiveLeftPlane.moveAbove(other: self.notesRightPlane)
 
-        let isLiveRightWidth = min(UInt32("\(item.isLive)".count), state.width - 11)
+        let isLiveRightWidth = min("\(item.isLive)".terminalColumnWidth, state.width - 11)
         guard
             let isLiveRightPlane = Plane(
                 in: pagePlane,

--- a/Sources/Yatoro/UI/Pages/NowPlayingPage.swift
+++ b/Sources/Yatoro/UI/Pages/NowPlayingPage.swift
@@ -491,15 +491,15 @@ public class NowPlayingPage: DestroyablePage {
             self.durationPlane.updateByPageState(.init(absX: 2, absY: 4, width: 1, height: 1))
             return
         }
-        var width = min(UInt32(currentSong.artistName.count), self.state.width - 11)
+        var width = min(currentSong.artistName.terminalColumnWidth, self.state.width - 11)
         self.artistRightPlane.erase()
         self.artistRightPlane.updateByPageState(.init(absX: 10, absY: 2, width: width, height: 1))
         self.artistRightPlane.putString(currentSong.artistName, at: (0, 0))
-        width = min(UInt32(currentSong.title.count), self.state.width - 11)
+        width = min(currentSong.title.terminalColumnWidth, self.state.width - 11)
         self.songRightPlane.erase()
         self.songRightPlane.updateByPageState(.init(absX: 10, absY: 3, width: width, height: 1))
         self.songRightPlane.putString(currentSong.title, at: (0, 0))
-        width = min(UInt32(currentSong.albumTitle?.count ?? 3), self.state.width - 11)
+        width = min((currentSong.albumTitle ?? "nil").terminalColumnWidth, self.state.width - 11)
         self.albumRightPlane.erase()
         self.albumRightPlane.updateByPageState(.init(absX: 10, absY: 4, width: width, height: 1))
         self.albumRightPlane.putString(currentSong.albumTitle ?? "nil", at: (0, 0))

--- a/Sources/Yatoro/UI/Pages/QueuePage.swift
+++ b/Sources/Yatoro/UI/Pages/QueuePage.swift
@@ -14,7 +14,7 @@ public class QueuePage: Page {
 
     private var state: PageState
 
-    private var currentQueue: ApplicationMusicPlayer.Queue.Entries?
+    private var currentQueue: [Song]?
     private var cache: [Page]
 
     private var maxItemsDisplayed: Int {
@@ -193,7 +193,7 @@ public class QueuePage: Page {
             logger?.error("QueuePage: Unhandled shuffle mode.")
         }
 
-        guard currentQueue != Player.shared.queue else {
+        guard currentQueue != Player.shared.queueSongs else {
             return
         }
         logger?.debug("Queue UI update")
@@ -201,30 +201,27 @@ public class QueuePage: Page {
             await item.destroy()
         }
         cache = []
-        currentQueue = Player.shared.queue
+        currentQueue = Player.shared.queueSongs
         var i = 0
         for itemIndex in currentQueue!.indices {
-            switch currentQueue![itemIndex].item {
-            case .song(let song):
-                guard
-                    let page = SongItemPage(
-                        in: self.borderPlane,
-                        state: .init(
-                            absX: 1,
-                            absY: 1 + Int32(i) * 5,
-                            width: state.width - 2,
-                            height: 5
-                        ),
-                        type: .queuePage,
-                        item: song
-                    )
-                else {
-                    continue
-                }
-                i += 1
-                self.cache.append(page)
-            default: break
+            let song = currentQueue![itemIndex]
+            guard
+                let page = SongItemPage(
+                    in: self.borderPlane,
+                    state: .init(
+                        absX: 1,
+                        absY: 1 + Int32(i) * 5,
+                        width: state.width - 2,
+                        height: 5
+                    ),
+                    type: .queuePage,
+                    item: song
+                )
+            else {
+                continue
             }
+            i += 1
+            self.cache.append(page)
             if itemIndex >= maxItemsDisplayed {
                 break
             }

--- a/Sources/Yatoro/UI/Pages/SearchPage.swift
+++ b/Sources/Yatoro/UI/Pages/SearchPage.swift
@@ -242,7 +242,7 @@ public class SearchPage: DestroyablePage {
                     pageNamePlane.putString("Catalog stations:", at: (0, 0))
                 }
                 let searchPhrasePlaneWidth = min(
-                    UInt32(searchPhrase.count),
+                    searchPhrase.terminalColumnWidth,
                     self.state.width - pageNamePlane.width - 4
                 )
                 searchPhrasePlane.updateByPageState(
@@ -282,7 +282,7 @@ public class SearchPage: DestroyablePage {
                     .init(
                         absX: Int32(pageNamePlane.width) + 3,
                         absY: 0,
-                        width: UInt32(searchPhrase.count),
+                        width: searchPhrase.terminalColumnWidth,
                         height: 1
                     )
                 )
@@ -328,7 +328,7 @@ public class SearchPage: DestroyablePage {
 
                 // Open Playlist in-place
                 let name = playlistDescription.playlist.name
-                pageNamePlane.width = UInt32(name.count)
+                pageNamePlane.width = name.terminalColumnWidth
                 pageNamePlane.putString(name, at: (0, 0))
                 searchPhrasePlane.updateByPageState(.init(absX: 2, absY: 0, width: 1, height: 1))
                 searchPhrasePlane.erase()

--- a/Sources/Yatoro/UI/UI.swift
+++ b/Sources/Yatoro/UI/UI.swift
@@ -47,6 +47,7 @@ public class UI {
             fatalError("Failed to initialize notcurses UI.")
         }
         UI.notcurses = notcurses
+        Self.resetGhosttyKeyboardProtocol()
         logger?.debug("Notcurses initialized.")
 
         guard let stdPlane = Plane(in: notcurses) else {
@@ -128,8 +129,205 @@ public class UI {
         guard input.eventType != .release else {
             return
         }
+        // Drain all available input in one pass so that escape sequences
+        // (e.g. Ghostty bracketed-paste \e[200~...\e[201~ or IME sequences)
+        // are normalized before InputQueue processes the leading ESC.
+        var inputs = [input]
         logger?.trace("New input: \(input)")
-        inputQueue.add(input)
+        while let extra = Input(notcurses: notcurses) {
+            guard extra.eventType != .release else { continue }
+            logger?.trace("New input: \(extra)")
+            inputs.append(extra)
+        }
+        for input in normalizeInputs(inputs) {
+            inputQueue.add(input)
+        }
+    }
+
+    private func normalizeInputs(_ inputs: [Input]) -> [Input] {
+        var normalized: [Input] = []
+        var index = inputs.startIndex
+
+        while index < inputs.endIndex {
+            if let result = decodeBareCSIUInput(in: inputs, startingAt: index) {
+                normalized.append(result.input)
+                index = result.nextIndex
+                continue
+            }
+
+            if let result = decodeCSIUInput(in: inputs, startingAt: index) {
+                normalized.append(result.input)
+                index = result.nextIndex
+                continue
+            }
+
+            normalized.append(inputs[index])
+            index = inputs.index(after: index)
+        }
+
+        return normalized
+    }
+
+    private func decodeBareCSIUInput(
+        in inputs: [Input],
+        startingAt startIndex: Array<Input>.Index
+    ) -> (input: Input, nextIndex: Array<Input>.Index)? {
+        let input = inputs[startIndex]
+
+        if input.id > 0x7F, input.utf8 == "u",
+            let decoded = inputForBareUnicodeScalar(input.id)
+        {
+            return (decoded, inputs.index(after: startIndex))
+        }
+
+        if input.modifiers.isEmpty, input.utf8.hasSuffix("u") {
+            let codepoint = String(input.utf8.dropLast())
+            if let decoded = inputForBareUnicodeScalar(codepoint) {
+                return (decoded, inputs.index(after: startIndex))
+            }
+        }
+
+        var index = startIndex
+        var codepoint = ""
+
+        while index < inputs.endIndex {
+            guard let token = token(for: inputs[index]) else {
+                return nil
+            }
+
+            if token == "u" {
+                guard let decoded = inputForBareUnicodeScalar(codepoint) else {
+                    return nil
+                }
+                return (decoded, inputs.index(after: index))
+            }
+
+            guard token.count == 1, token.allSatisfy(\.isNumber) else {
+                return nil
+            }
+            codepoint.append(token)
+            index = inputs.index(after: index)
+        }
+
+        return nil
+    }
+
+    private func decodeCSIUInput(
+        in inputs: [Input],
+        startingAt startIndex: Array<Input>.Index
+    ) -> (input: Input, nextIndex: Array<Input>.Index)? {
+        guard token(for: inputs[startIndex]) == "\u{1B}" else {
+            return nil
+        }
+
+        var index = inputs.index(after: startIndex)
+        guard index < inputs.endIndex, token(for: inputs[index]) == "[" else {
+            return nil
+        }
+
+        index = inputs.index(after: index)
+        var codepoint = ""
+
+        while index < inputs.endIndex {
+            guard let token = token(for: inputs[index]) else {
+                return nil
+            }
+
+            if token == "u" {
+                guard let decoded = inputForUnicodeScalar(codepoint) else {
+                    return nil
+                }
+                return (decoded, inputs.index(after: index))
+            }
+
+            if token == ";" {
+                guard !codepoint.isEmpty else {
+                    return nil
+                }
+                return decodeCSIUInputWithModifiers(
+                    codepoint: codepoint,
+                    in: inputs,
+                    startingAt: inputs.index(after: index)
+                )
+            }
+
+            guard token.count == 1, token.allSatisfy(\.isNumber) else {
+                return nil
+            }
+            codepoint.append(token)
+            index = inputs.index(after: index)
+        }
+
+        return nil
+    }
+
+    private func decodeCSIUInputWithModifiers(
+        codepoint: String,
+        in inputs: [Input],
+        startingAt startIndex: Array<Input>.Index
+    ) -> (input: Input, nextIndex: Array<Input>.Index)? {
+        var index = startIndex
+
+        while index < inputs.endIndex {
+            guard let token = token(for: inputs[index]) else {
+                return nil
+            }
+
+            if token == "u" {
+                guard let decoded = inputForUnicodeScalar(codepoint) else {
+                    return nil
+                }
+                return (decoded, inputs.index(after: index))
+            }
+
+            guard token.count == 1, token.allSatisfy(\.isNumber) else {
+                return nil
+            }
+            index = inputs.index(after: index)
+        }
+
+        return nil
+    }
+
+    private func inputForBareUnicodeScalar(_ codepoint: String) -> Input? {
+        guard let scalarValue = UInt32(codepoint) else {
+            return nil
+        }
+        return inputForBareUnicodeScalar(scalarValue)
+    }
+
+    private func inputForBareUnicodeScalar(_ scalarValue: UInt32) -> Input? {
+        guard scalarValue >= 0x1000 else {
+            return nil
+        }
+        return inputForUnicodeScalar(scalarValue)
+    }
+
+    private func inputForUnicodeScalar(_ codepoint: String) -> Input? {
+        guard let scalarValue = UInt32(codepoint) else {
+            return nil
+        }
+        return inputForUnicodeScalar(scalarValue)
+    }
+
+    private func inputForUnicodeScalar(_ scalarValue: UInt32) -> Input? {
+        guard
+            scalarValue > 0x7F,
+            let scalar = UnicodeScalar(scalarValue)
+        else {
+            return nil
+        }
+        return Input(utf8: String(Character(scalar)))
+    }
+
+    private func token(for input: Input) -> String? {
+        if input.id == 27 || input.utf8 == "\u{1B}" {
+            return "\u{1B}"
+        }
+        guard input.modifiers.isEmpty, input.utf8.count == 1 else {
+            return nil
+        }
+        return input.utf8
     }
 
     public func stop() async {
@@ -148,11 +346,23 @@ public class UI {
                 FileHandle.standardOutput.write(sequence.data(using: .utf8)!)
             }
         }
+        Self.resetGhosttyKeyboardProtocol()
 
         UI.notcurses?.stop()
         logger?.debug("Notcurses stopped.")
         logger?.info("Yatoro stopped.\n")
         exit(EXIT_SUCCESS)
+    }
+
+    private static func resetGhosttyKeyboardProtocol() {
+        guard
+            ProcessInfo.processInfo.environment["TERM_PROGRAM"]?.lowercased() == "ghostty"
+        else {
+            return
+        }
+
+        let sequence = "\u{1B}[<u"
+        FileHandle.standardOutput.write(sequence.data(using: .utf8)!)
     }
 
 }

--- a/Sources/Yatoro/Yatoro.swift
+++ b/Sources/Yatoro/Yatoro.swift
@@ -168,6 +168,7 @@ struct Yatoro: AsyncParsableCommand {
 
         let player = Player.shared
         await player.authorize()
+        await player.restoreQueue()
 
         let ui = await UI()
         await ui.start()


### PR DESCRIPTION
## Summary

- Fix command-line insertion for pasted Unicode text so multi-character input, including multiple Chinese characters, is inserted completely instead of being truncated.
- Reset Ghostty's Kitty keyboard protocol mode on startup and shutdown so Chinese IME input in commands such as `:search` is received as normal UTF-8.
- Add a fallback normalizer for CSI-u encoded Unicode input, including Ghostty/notcurses cases where sequences may leak through as codepoint forms like `25991u`.

## Root cause

Command input previously treated `Input.utf8` as a single `Character`, which could lose pasted multi-character text. In Ghostty, notcurses can leave Kitty keyboard protocol enabled, causing Chinese input to arrive as CSI-u codepoint sequences instead of regular UTF-8.

## Testing

- `swift build`
- Manually verified Chinese input in Ghostty command mode, including `:search` and pasted Chinese text.